### PR TITLE
fix(PE-3444): update warp-contracts and use inMemory caching until ContractDefinitionsLoader implements caching

### DIFF
--- a/src/api/warp.ts
+++ b/src/api/warp.ts
@@ -1,4 +1,4 @@
-import { Warp } from "warp-contracts";
+import { SourceType, Warp } from "warp-contracts";
 
 const requestMap: Map<string, Promise<any> | undefined> = new Map();
 
@@ -9,7 +9,10 @@ export async function getContractState(id: string, warp: Warp) {
     return await requestMap.get(id);
   }
 
-  const contract = warp.contract(id);
+  const contract = warp.contract(id).setEvaluationOptions({
+    // restrain to L1 tx's only
+    sourceType: SourceType.ARWEAVE,
+  });
   // set cached value for multiple requests during initial promise
   requestMap.set(id, contract.readState());
   // await the response

--- a/src/middleware/warp.ts
+++ b/src/middleware/warp.ts
@@ -6,24 +6,37 @@ import {
   WarpFactory,
   defaultCacheOptions,
 } from "warp-contracts";
-import { LmdbCache } from "warp-contracts-lmdb";
 
 LoggerFactory.INST.logLevel(
-  (process.env.WARP_LOG_LEVEL as LogLevel) ?? "fatal"
+  (process.env.WARP_LOG_LEVEL as LogLevel) ?? "debug"
 );
 
 export function warpMiddleware(ctx: KoaContext, next: Next) {
   const { arweave } = ctx.state;
 
-  // TODO: setting useArweaveGw to true shows error
-  const warp = WarpFactory.forMainnet(defaultCacheOptions, false, arweave)
-    .useStateCache(new LmdbCache(defaultCacheOptions))
-    .useContractCache(
-      // Contract cache
-      new LmdbCache(defaultCacheOptions),
-      // Source cache
-      new LmdbCache(defaultCacheOptions)
-    );
+  /**
+     * TODO: ContractDefinitionsLoader does not have cache implemented when using custom arweave config, so use inMemory for now. Once it is updated, we should revert back to LMDB cache implementation.
+     * 
+     * Reference: https://github.com/warp-contracts/warp/blob/cde7b07f9495f09e998b13d1fe2661b0af0a3b74/src/core/modules/impl/ContractDefinitionLoader.ts#L150-L165
+     * e.g. 
+        const warp = WarpFactory.forMainnet(defaultCacheOptions, true, arweave)
+        .useStateCache(
+            new LmdbCache(defaultCacheOptions)
+        ).useContractCache(
+            // Contract cache
+            new LmdbCache(defaultCacheOptions), 
+            // Source cache
+            new LmdbCache(defaultCacheOptions)
+        );
+     */
+  const warp = WarpFactory.forMainnet(
+    {
+      ...defaultCacheOptions,
+      inMemory: true,
+    },
+    true,
+    arweave
+  );
   ctx.state.warp = warp;
   return next();
 }


### PR DESCRIPTION
Was dependent on https://github.com/ar-io/ar-io-node/commit/8e677933eafcb3a48bae53f4a71c41deb20b5391