### PR TITLE
feat(PE-3607): add endpoint to fetch all contract interactions

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,5 @@
+# CODEOWNERS
+
+# The @ar-io/services team is the code owner for the entire repository.
+
+* @ar-io/services

--- a/src/api/graphql.ts
+++ b/src/api/graphql.ts
@@ -1,4 +1,5 @@
 import Arweave from "arweave";
+import { ArNSInteraction } from "../types.js";
 
 export async function getDeployedContractsForWallet(
   arweave: Arweave,
@@ -73,8 +74,8 @@ export async function getDeployedContractsForWallet(
 
 export async function getWalletInteractionsForContract(
   arweave: Arweave,
-  params: { address: string; contractId: string }
-): Promise<{ interactions: Map<string, any> }> {
+  params: { address?: string; contractId: string }
+): Promise<{ interactions: Map<string, Omit<ArNSInteraction, 'valid' | 'errorMessage'>> }> {
   const { address, contractId } = params;
   let hasNextPage = false;
   let cursor: string | undefined;
@@ -84,7 +85,7 @@ export async function getWalletInteractionsForContract(
       query: `
                 { 
                     transactions (
-                        owners:["${address}"],
+                        owners: ${address ? `["${address}"]`: '[]'},
                         tags:[
                             {
                                 name:"Contract",

--- a/src/api/warp.ts
+++ b/src/api/warp.ts
@@ -17,5 +17,5 @@ export async function getContractState(id: string, warp: Warp) {
   // remove the cached value once it's been retrieved
   requestMap.delete(id);
 
-  return cachedValue.state;
+  return cachedValue;
 }

--- a/src/router.ts
+++ b/src/router.ts
@@ -8,6 +8,7 @@ import {
   contractBalanceHandler,
   contractFieldHandler,
   contractHandler,
+  contractInteractionsHandler,
   contractRecordHandler,
   prometheusHandler,
   walletContractHandler,
@@ -26,6 +27,7 @@ router.get("/healthcheck", (ctx) => {
 });
 
 router.get(`/contract/:id${PDNS_CONTRACT_ID_REGEX}`, contractHandler);
+router.get(`/contract/:id${PDNS_CONTRACT_ID_REGEX}/interactions`, contractInteractionsHandler);
 router.get(
   `/contract/:id${PDNS_CONTRACT_ID_REGEX}/:field${PDNS_CONTRACT_FIELD_REGEX}`,
   contractFieldHandler

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,5 +1,5 @@
 import { DefaultState, ParameterizedContext } from "koa";
-import { Warp } from "warp-contracts";
+import { PstState, Warp } from "warp-contracts";
 import winston from "winston";
 
 export type KoaState = {
@@ -9,12 +9,29 @@ export type KoaState = {
 
 export type KoaContext = ParameterizedContext<KoaState>;
 
-export type PDNSRecordEntry = {
-  endTimestamp: number;
-  contractTxId: string;
-  tier: string;
-};
-
 export type DeployedContractsRequestBody = {
   sourceCodeTxIds: string[];
 };
+
+export type ArNSRecord = {
+  transactionId: string,
+  [x: string]: any
+}
+
+export type ArNSState = PstState & { records: { [x:string]: ArNSRecord } }
+
+export type PstInput = {
+  function: string,
+  [x: string]: string
+}
+
+export type ArNSInteraction = {
+  valid: boolean,
+  input: PstInput,
+  height: number,
+  errorMessage?: string,
+}
+
+export type ArNSContractInteractions = {
+  [x: string]: ArNSInteraction
+}


### PR DESCRIPTION
This endpiont returns all the contract interactions for a given contract, with priority given to graphql. We may want to validate the interctions are the same from graphql and warp, but for now we'll use graphql to tell us what's relevant and use warp to determine if they were successful or failed. So long as the warp on configuration and the arweave client use the same gateway, they *should* return the same interactions.