### PR TITLE
fix(middleware): instantiate middleware outside of handler function t…

### DIFF
--- a/src/middleware/arweave.ts
+++ b/src/middleware/arweave.ts
@@ -2,13 +2,13 @@ import { Next } from "koa";
 import { KoaContext } from "../types.js";
 import Arweave from "arweave";
 
-export function arweaveMiddleware(ctx: KoaContext, next: Next) {
-  const arweave = new Arweave({
-    protocol: "https",
-    port: 443,
-    host: process.env.GATEWAY_HOST ?? "ar-io.dev",
-  });
+export const arweave = new Arweave({
+  protocol: "https",
+  port: 443,
+  host: process.env.GATEWAY_HOST ?? "ar-io.dev",
+});
 
+export function arweaveMiddleware(ctx: KoaContext, next: Next) {
   ctx.state.arweave = arweave;
   return next();
 }

--- a/src/middleware/warp.ts
+++ b/src/middleware/warp.ts
@@ -6,37 +6,37 @@ import {
   WarpFactory,
   defaultCacheOptions,
 } from "warp-contracts";
+import { arweave } from "./arweave";
 
 LoggerFactory.INST.logLevel(
   (process.env.WARP_LOG_LEVEL as LogLevel) ?? "fatal"
 );
 
-export function warpMiddleware(ctx: KoaContext, next: Next) {
-  const { arweave } = ctx.state;
+/**
+   * TODO: ContractDefinitionsLoader does not have cache implemented when using custom arweave config, so use inMemory for now. Once it is updated, we should revert back to LMDB cache implementation.
+   * 
+   * Reference: https://github.com/warp-contracts/warp/blob/cde7b07f9495f09e998b13d1fe2661b0af0a3b74/src/core/modules/impl/ContractDefinitionLoader.ts#L150-L165
+   * e.g. 
+      const warp = WarpFactory.forMainnet(defaultCacheOptions, true, arweave)
+      .useStateCache(
+          new LmdbCache(defaultCacheOptions)
+      ).useContractCache(
+          // Contract cache
+          new LmdbCache(defaultCacheOptions), 
+          // Source cache
+          new LmdbCache(defaultCacheOptions)
+      );
+*/
+const warp = WarpFactory.forMainnet(
+  {
+    ...defaultCacheOptions,
+    inMemory: true,
+  },
+  true,
+  arweave
+);
 
-  /**
-     * TODO: ContractDefinitionsLoader does not have cache implemented when using custom arweave config, so use inMemory for now. Once it is updated, we should revert back to LMDB cache implementation.
-     * 
-     * Reference: https://github.com/warp-contracts/warp/blob/cde7b07f9495f09e998b13d1fe2661b0af0a3b74/src/core/modules/impl/ContractDefinitionLoader.ts#L150-L165
-     * e.g. 
-        const warp = WarpFactory.forMainnet(defaultCacheOptions, true, arweave)
-        .useStateCache(
-            new LmdbCache(defaultCacheOptions)
-        ).useContractCache(
-            // Contract cache
-            new LmdbCache(defaultCacheOptions), 
-            // Source cache
-            new LmdbCache(defaultCacheOptions)
-        );
-     */
-  const warp = WarpFactory.forMainnet(
-    {
-      ...defaultCacheOptions,
-      inMemory: true,
-    },
-    true,
-    arweave
-  );
+export function warpMiddleware(ctx: KoaContext, next: Next) {
   ctx.state.warp = warp;
   return next();
 }


### PR DESCRIPTION
…o avoid overwriting on each request

Identified by @fedellen in `payment-service` that these are getting reinstantiated on each request. Would likely lead to poor warp caching on heavy requests.