### PR TITLE
fix(PE-3794): use arns_metrics in place of metrics so OTEL collector …

### DIFF
--- a/src/router.ts
+++ b/src/router.ts
@@ -51,6 +51,6 @@ router.get(
   `/wallet/:address${PDNS_CONTRACT_ID_REGEX}/contract/:id${PDNS_CONTRACT_ID_REGEX}`,
   walletInteractionHandler
 );
-router.get("/metrics", prometheusHandler);
+router.get("/arns_metrics", prometheusHandler);
 
 export default router;

--- a/tests/integration/routes.test.ts
+++ b/tests/integration/routes.test.ts
@@ -27,7 +27,7 @@ describe("PDNS Service Integration tests", () => {
     });
 
     it("should return 200 prometheus", async () => {
-      const { status, data } = await axios.get(`/metrics`);
+      const { status, data } = await axios.get(`/arns_metrics`);
       expect(status).to.equal(200);
       expect(data).to.not.be.undefined;
     });


### PR DESCRIPTION
…regex can find metrics route