### PR TITLE
chore(PE-3756): add contract evluation options for new contract-manifest

### DIFF
--- a/src/api/warp.ts
+++ b/src/api/warp.ts
@@ -19,7 +19,14 @@ export async function getContractState(
   const contract = warp.contract(id).setEvaluationOptions({
     // restrain to L1 tx's only
     sourceType: SourceType.ARWEAVE,
+    // TODO: these will need to match the contract or be provided as params
+    unsafeClient: "skip",
+    internalWrites: true,
+    maxCallDepth: 3,
+    waitForConfirmation: true,
+    updateCacheForEachInteraction: true,
   });
+
   // set cached value for multiple requests during initial promise
   requestMap.set(id, contract.readState());
   // await the response


### PR DESCRIPTION
We could introduce a new endpoint that allows a client to pass these evaultation options. We'll test this for now.