### PR TITLE
feat(PE-4063): add owner to records route

### DIFF
--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -37,8 +37,8 @@ export type ArNSContractInteractions = {
 
 export type ContractType = (typeof allowedContractTypes)[number];
 export type ContractRecordResponse = {
-  contract: string,
-  record: unknown,
-  owner?: string,
-  name: string
-}
+  contract: string;
+  record: unknown;
+  owner?: string;
+  name: string;
+};

--- a/tests/integration/setup.test.ts
+++ b/tests/integration/setup.test.ts
@@ -44,14 +44,44 @@ export async function mochaGlobalSetup() {
     )
   );
 
-  // deploy contract to arlocal
+  // deploy example any contract
+  const { contractTxId: antContractTxId } = await warp.deploy(
+    {
+      wallet,
+      initState: JSON.stringify({
+        ...initState,
+        ticker: "ANT-TEST",
+        owner: address,
+        controller: address,
+        records: {
+          "@": {
+            transactionId: "a-fake-transaction-id",
+          },
+        },
+        balances: {
+          [address]: 1,
+        },
+      }),
+      src: contractSrcJs,
+    },
+    true // disable bundling
+  );
+
+  // deploy registry contract to arlocal
   const { contractTxId } = await warp.deploy(
     {
       wallet,
       initState: JSON.stringify({
         ...initState,
+        ticker: "ArNS-REGISTRY-TEST",
         owner: address,
         controller: address,
+        records: {
+          example: {
+            contractTxId: antContractTxId,
+          },
+          "no-owner": "no-owner",
+        },
         balances: {
           [address]: 1,
         },
@@ -62,7 +92,9 @@ export async function mochaGlobalSetup() {
   );
 
   // set in the environment
-  process.env.DEPLOYED_CONTRACT_TX_ID = contractTxId;
+  process.env.DEPLOYED_REGISTRY_CONTRACT_TX_ID = contractTxId;
+  process.env.DEPLOYED_ANT_CONTRACT_TX_ID = antContractTxId;
+  console.log(antContractTxId);
   console.log(
     "Successfully setup ArLocal and deployed contract.",
     contractTxId


### PR DESCRIPTION
If the record field has `contractTxId` - we'll attempt to load the state and return the owner with record field.
```
❯ curl -iL http://localhost:3000/contract/bLAgYxAdX2Ry-nt6aH2ixgvJXbpsEYm28NgJgyqfs-U/records/dylan
HTTP/1.1 200 OK
Vary: Origin
Access-Control-Allow-Origin: 
Content-Type: application/json; charset=utf-8
Cache-Control: max-age=120
Content-Length: 271
Date: Thu, 22 Jun 2023 14:45:39 GMT
Connection: keep-alive
Keep-Alive: timeout=5

{"contract":"bLAgYxAdX2Ry-nt6aH2ixgvJXbpsEYm28NgJgyqfs-U","name":"dylan","record":{"contractTxId":"gh673M0Koh941OIITVXl9hKabRaYWABQUedZxW-swIA","endTimestamp":1711228201,"tier":"a27dbfe4-6992-4276-91fb-5b97ae8c3ffa"},"owner":"ZjmB2vEUlHlJ7-rgJkYP09N5IzLPhJyStVrK5u9dDEo"}
```