### PR TITLE
feat: add endtimestamp check to reserved name endpoint. 

### DIFF
--- a/src/routes/contract.ts
+++ b/src/routes/contract.ts
@@ -294,11 +294,18 @@ export async function contractReservedHandler(ctx: KoaContext, next: Next) {
     });
     const reservedName = state['reserved'][name];
 
+    // validate if the name is still reserved
+    // TODO: should this be using block height instead to avoid clock time issues
+    const reserved =
+      !!reservedName &&
+      reservedName.endTimestamp &&
+      reservedName.endTimestamp > Date.now();
+
     const response: ContractReservedResponse = {
       contractTxId,
       name,
-      reserved: !!reservedName,
-      ...(reservedName ? { details: reservedName } : {}),
+      reserved,
+      ...(reserved ? { details: reservedName } : {}),
       evaluationOptions,
     };
 


### PR DESCRIPTION
Because the state may not be ticked, we need to confirm the endTimestamp has not been met. If it has, then the name should be purchasable assuming it has a timestamptate may not be ticked, we need to confirm the endTimestamp has not been met. If it has, then the name should be purchasable assuming it has a timestamp