### PR TITLE
fix(cache): drop default cache headers to 30 seconds - PE-4573

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "koa2-swagger-ui": "^5.8.0",
     "lodash": "^4.17.21",
     "prom-client": "^14.2.0",
-    "warp-contracts": "^1.4.12",
+    "warp-contracts": "^1.4.18",
     "warp-contracts-lmdb": "^1.1.10",
     "winston": "^3.8.2",
     "yaml": "^2.3.1"

--- a/src/middleware/headers.ts
+++ b/src/middleware/headers.ts
@@ -1,7 +1,7 @@
 import { Next } from 'koa';
 import { KoaContext } from '../types';
 
-const MAX_AGE_SECONDS = process.env.MAX_AGE_SECONDS ?? 120;
+const MAX_AGE_SECONDS = process.env.MAX_AGE_SECONDS ?? 30;
 
 export async function headersMiddleware(ctx: KoaContext, next: Next) {
   const { logger } = ctx.state;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6790,6 +6790,13 @@ underscore@>=1.3.1:
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.13.6.tgz#04786a1f589dc6c09f761fc5f45b89e935136441"
   integrity sha512-+A5Sja4HP1M08MaXya7p5LvjuM7K6q/2EaC0+iovj/wOcMsTzMvDFbasi/oSapiwOlt252IqsKqPjCl7huKS0A==
 
+undici@^5.19.1:
+  version "5.24.0"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-5.24.0.tgz#6133630372894cfeb3c3dab13b4c23866bd344b5"
+  integrity sha512-OKlckxBjFl0oXxcj9FU6oB8fDAaiRUq+D8jrFWGmOfI/gIyjk/IeS75LMzgYKUaeHzLUcYvf9bbJGSrUwTfwwQ==
+  dependencies:
+    busboy "^1.6.0"
+
 undici@^5.8.0:
   version "5.22.1"
   resolved "https://registry.yarnpkg.com/undici/-/undici-5.22.1.tgz#877d512effef2ac8be65e695f3586922e1a57d7b"
@@ -6912,6 +6919,16 @@ vm-browserify@^1.0.1:
   resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-1.1.2.tgz#78641c488b8e6ca91a75f511e7a3b32a86e5dda0"
   integrity sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==
 
+warp-arbundles@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/warp-arbundles/-/warp-arbundles-1.0.4.tgz#10c0cd662ab41b0dabad9159c7110f43425cc5cc"
+  integrity sha512-KeRac/EJ7VOK+v5+PSMh2SrzpCKOAFnJICLlqZWt6qPkDCzVwcrNE5wFxOlEk5U170ewMDAB3e86UHUblevXpw==
+  dependencies:
+    arweave "^1.13.7"
+    base64url "^3.0.1"
+    buffer "^6.0.3"
+    warp-isomorphic "^1.0.7"
+
 warp-contracts-lmdb@^1.1.10:
   version "1.1.10"
   resolved "https://registry.yarnpkg.com/warp-contracts-lmdb/-/warp-contracts-lmdb-1.1.10.tgz#f81f85c36bc7c5afdfa7aab897187051acf7479f"
@@ -6928,10 +6945,10 @@ warp-contracts-plugin-deploy@^1.0.8:
     arlocal "^1.1.59"
     node-stdlib-browser "^1.2.0"
 
-warp-contracts@^1.4.12:
-  version "1.4.12"
-  resolved "https://registry.yarnpkg.com/warp-contracts/-/warp-contracts-1.4.12.tgz#b1681fc0b81e9128c272d7ce8f417319ce5fb969"
-  integrity sha512-DjmxN4U26jzYhlumTj1QgxH1GPmjN2oAkTXDGBvXSpdLYvf0n3aGJLBVYddfH9P/IQlxcQJ6KaXS4Ihlq9FrAw==
+warp-contracts@^1.4.18:
+  version "1.4.18"
+  resolved "https://registry.yarnpkg.com/warp-contracts/-/warp-contracts-1.4.18.tgz#a53d5bf8e6b5da89181d6511e99f8f1ab39e4783"
+  integrity sha512-AWPen9agSJvWW5n42E8iIf/M+/jMpMuArQZYSXHeEjq/5/ln9c6dHcrUUtSSQMBuTigirukGR4T9kmYY3pIE8Q==
   dependencies:
     archiver "^5.3.0"
     arweave "1.13.7"
@@ -6944,7 +6961,8 @@ warp-contracts@^1.4.12:
     safe-stable-stringify "2.4.1"
     stream-buffers "^3.0.2"
     unzipit "^1.4.0"
-    warp-isomorphic "1.0.4"
+    warp-arbundles "^1.0.4"
+    warp-isomorphic "^1.0.7"
     warp-wasm-metering "1.0.1"
 
 warp-isomorphic@1.0.0:
@@ -6955,13 +6973,13 @@ warp-isomorphic@1.0.0:
     buffer "^6.0.3"
     undici "^5.8.0"
 
-warp-isomorphic@1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/warp-isomorphic/-/warp-isomorphic-1.0.4.tgz#1017eba260e0f0228b33b94b9e36a1afe54e09d8"
-  integrity sha512-W77IoLjq/eu5bY1uRrlmVt5lLDoIHeZ0ozJ/j67FTnxvZRXu887biEnom1nx8q1UgOKyJh8eQYFQaE2FLlKhFg==
+warp-isomorphic@^1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/warp-isomorphic/-/warp-isomorphic-1.0.7.tgz#abf1ee7bce44bec7c6b97547859e614876869aa7"
+  integrity sha512-fXHbUXwdYqPm9fRPz8mjv5ndPco09aMQuTe4kXfymzOq8V6F3DLsg9cIafxvjms9/mc6eijzkLBJ63yjEENEjA==
   dependencies:
     buffer "^6.0.3"
-    undici "^5.8.0"
+    undici "^5.19.1"
 
 warp-wasm-json-toolkit@1.0.2:
   version "1.0.2"


### PR DESCRIPTION
Related - https://github.com/ar-io/arns-service/pull/38