### PR TITLE
feat(lmdb): use warp-contracts-lmdb for contract caching

### DIFF
--- a/src/middleware/warp.ts
+++ b/src/middleware/warp.ts
@@ -7,34 +7,22 @@ import {
   defaultCacheOptions,
 } from 'warp-contracts';
 import { arweave } from './arweave';
+import { LmdbCache } from 'warp-contracts-lmdb';
 
 LoggerFactory.INST.logLevel(
   (process.env.WARP_LOG_LEVEL as LogLevel) ?? 'fatal',
 );
 
 /**
-   * TODO: ContractDefinitionsLoader does not have cache implemented when using custom arweave config, so use inMemory for now. Once it is updated, we should revert back to LMDB cache implementation.
-   * 
-   * Reference: https://github.com/warp-contracts/warp/blob/cde7b07f9495f09e998b13d1fe2661b0af0a3b74/src/core/modules/impl/ContractDefinitionLoader.ts#L150-L165
-   * e.g. 
-      const warp = WarpFactory.forMainnet(defaultCacheOptions, true, arweave)
-      .useStateCache(
-          new LmdbCache(defaultCacheOptions)
-      ).useContractCache(
-          // Contract cache
-          new LmdbCache(defaultCacheOptions), 
-          // Source cache
-          new LmdbCache(defaultCacheOptions)
-      );
-*/
+ * TODO: consider using warp-contracts-postgres cache for distribution caching (or EFS with warp-contracts-lmdb or warp-contracts-sqlite)
+ */
 const warp = WarpFactory.forMainnet(
   {
     ...defaultCacheOptions,
-    inMemory: true,
   },
   true,
   arweave,
-);
+).useStateCache(new LmdbCache(defaultCacheOptions));
 
 export function warpMiddleware(ctx: KoaContext, next: Next) {
   ctx.state.warp = warp;


### PR DESCRIPTION
There are other options available, but in-memory can be a bit finicky when lots of requests come in. Eventually we should consider moving to a distributed DB cache (postgres) or sqlite/lmdb in EFS.