### PR TITLE
feat(filter): filter records by contractTxId

### DIFF
--- a/docs/openapi.yaml
+++ b/docs/openapi.yaml
@@ -125,6 +125,64 @@ paths:
         '503':
           description: Internal server error.
 
+  /v1/contract/{contractTxId}/records:
+    get:
+      summary: Returns the record objects for a given contract, who's object parameters match query parameters
+      parameters:
+        - in: path
+          name: contractTxId
+          required: true
+          description: ID of the root contract.
+          schema:
+            type: string
+            example: 'E-pRI1bokGWQBqHnbut9rsHSt9Ypbldos3bAtwg4JMc'
+        - in: query
+          name: contractTxId
+          required: true
+          description: The contractTxID for the records to return
+          schema:
+            type: string
+            example: 'gh673M0Koh941OIITVXl9hKabRaYWABQUedZxW-swIA'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  contractTxId:
+                    type: string
+                    example: 'E-pRI1bokGWQBqHnbut9rsHSt9Ypbldos3bAtwg4JMc'
+                  records:
+                    type: array
+                    example:
+                      [
+                        'testname3':
+                          {
+                            'undernames': 100,
+                            'startTimestamp': 1694101828,
+                            'type': 'lease',
+                            'contractTxId': 'gh673M0Koh941OIITVXl9hKabRaYWABQUedZxW-swIA',
+                            'endTimestamp': 1714145976,
+                          },
+                        'testname11':
+                          {
+                            'undernames': 100,
+                            'startTimestamp': 1694101828,
+                            'type': 'lease',
+                            'contractTxId': 'gh673M0Koh941OIITVXl9hKabRaYWABQUedZxW-swIA',
+                            'endTimestamp': 1714581732,
+                          },
+                      ]
+                  evaluationOptions:
+                    type: object
+                    example: {}
+        '404':
+          description: Contract not found.
+        '503':
+          description: Internal server error.
+
   /v1/contract/{contractTxId}/records/{name}:
     get:
       summary: Returns the record object for a given contract and name

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -2,7 +2,7 @@ import { EvaluationOptions } from 'warp-contracts';
 
 export const ARNS_CONTRACT_ID_REGEX = '([a-zA-Z0-9-_s+]{43})';
 export const ARNS_CONTRACT_FIELD_REGEX =
-  '(balances|records|fees|ticker|owner|name|controller|auctions|settings|reserved|gateways|version)';
+  '(balances|fees|ticker|owner|name|controller|auctions|settings|reserved|gateways|version)';
 export const ARNS_NAME_REGEX = '([a-zA-Z0-9-s+]{1,51})';
 export const EVALUATION_TIMEOUT_MS = 10_000; // 10 sec state timeout
 export const allowedContractTypes = ['ant'] as const;

--- a/src/router.ts
+++ b/src/router.ts
@@ -9,6 +9,7 @@ import {
   contractFieldHandler,
   contractHandler,
   contractInteractionsHandler,
+  contractRecordFilterHandler,
   contractRecordHandler,
   contractReservedHandler,
   prometheusHandler,
@@ -41,20 +42,26 @@ router.get(
   contractInteractionsHandler,
 );
 router.get(
-  `/v1/contract/:contractTxId${ARNS_CONTRACT_ID_REGEX}/:field${ARNS_CONTRACT_FIELD_REGEX}`,
-  contractFieldHandler,
+  `/v1/contract/:contractTxId${ARNS_CONTRACT_ID_REGEX}/records/:name${ARNS_NAME_REGEX}`,
+  contractRecordHandler,
+);
+router.get(
+  // handles query params to filter records with a specific contractTxId (e.g. /v1/contract/<ARNS_REGISTRY>/records?contractTxId=<ARNS_CONTRACT_ID>)
+  `/v1/contract/:contractTxId${ARNS_CONTRACT_ID_REGEX}/records`,
+  contractRecordFilterHandler,
 );
 router.get(
   `/v1/contract/:contractTxId${ARNS_CONTRACT_ID_REGEX}/balances/:address${ARNS_CONTRACT_ID_REGEX}`,
   contractBalanceHandler,
 );
 router.get(
-  `/v1/contract/:contractTxId${ARNS_CONTRACT_ID_REGEX}/records/:name${ARNS_NAME_REGEX}`,
-  contractRecordHandler,
-);
-router.get(
   `/v1/contract/:contractTxId${ARNS_CONTRACT_ID_REGEX}/reserved/:name${ARNS_NAME_REGEX}`,
   contractReservedHandler,
+);
+// fallback for any other contract fields that don't include additional logic (i.e. this just returns partial contract state)
+router.get(
+  `/v1/contract/:contractTxId${ARNS_CONTRACT_ID_REGEX}/:field${ARNS_CONTRACT_FIELD_REGEX}`,
+  contractFieldHandler,
 );
 router.get(
   `/v1/wallet/:address${ARNS_CONTRACT_ID_REGEX}/contracts`,

--- a/tests/integration/routes.test.ts
+++ b/tests/integration/routes.test.ts
@@ -157,7 +157,6 @@ describe('PDNS Service Integration tests', () => {
           'balances',
           'owner',
           'name',
-          'records',
           'ticker',
           'owner',
           'controller',
@@ -182,6 +181,42 @@ describe('PDNS Service Integration tests', () => {
           );
           expect(status).to.equal(404);
         });
+
+        describe('/records?contractTxId', () => {
+          it('should return all records if no filter provided', async () => {
+            const { status, data } = await axios.get(
+              `/v1/contract/${id}/records`,
+            );
+            expect(status).to.equal(200);
+            expect(data).to.not.be.undefined;
+            const { contractTxId } = data;
+            expect(contractTxId).to.equal(id);
+            expect(Object.keys(data['records'])).to.have.length(2);
+          });
+
+          it('should return records that have contractTxId matching the query filter', async () => {
+            const { status, data } = await axios.get(
+              `/v1/contract/${id}/records?contractTxId=${process.env.DEPLOYED_ANT_CONTRACT_TX_ID}`,
+            );
+            expect(status).to.equal(200);
+            expect(data).to.not.be.undefined;
+            const { contractTxId } = data;
+            expect(contractTxId).to.equal(id);
+            expect(Object.keys(data['records'])).to.have.length(1);
+          });
+
+          it('should return empty records if the contractTxId does not match any record object', async () => {
+            const { status, data } = await axios.get(
+              `/v1/contract/${id}/records?contractTxId=not-a-real-tx-id`,
+            );
+            expect(status).to.equal(200);
+            expect(data).to.not.be.undefined;
+            const { contractTxId } = data;
+            expect(contractTxId).to.equal(id);
+            expect(Object.keys(data['records'])).to.have.length(0);
+          });
+        });
+
         describe('/records/:name', () => {
           it('should return the owner of record name when available', async () => {
             const { status, data } = await axios.get(


### PR DESCRIPTION
Allows a query param that filters out records that meet a specific contractTxId. We can extend this to multiple values allowed on records objects, but will start with this for now