### PR TITLE
feat(warp): bump warp-contracts to leverage safeGet on smartweave

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "koa2-swagger-ui": "^5.8.0",
     "lodash": "^4.17.21",
     "prom-client": "^14.2.0",
-    "warp-contracts": "^1.4.21",
+    "warp-contracts": "^1.4.22",
     "warp-contracts-lmdb": "^1.1.10",
     "winston": "^3.8.2",
     "yaml": "^2.3.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6964,10 +6964,10 @@ warp-contracts-plugin-deploy@^1.0.8:
     arlocal "^1.1.59"
     node-stdlib-browser "^1.2.0"
 
-warp-contracts@^1.4.21:
-  version "1.4.21"
-  resolved "https://registry.yarnpkg.com/warp-contracts/-/warp-contracts-1.4.21.tgz#ab654ca2b7f437d8626787bc9e25150a9488694d"
-  integrity sha512-Re5aUKPdYXomzGOGaHSobYtErS3s2AubZhwW8yA+Yh0ZJAzdiMQL9aoJV4xC5xgGR0HUgkt0gsjdF8x63F+Wfg==
+warp-contracts@^1.4.22:
+  version "1.4.22"
+  resolved "https://registry.yarnpkg.com/warp-contracts/-/warp-contracts-1.4.22.tgz#7a2bdf0774a13748be88296ecb8bc843436db9df"
+  integrity sha512-MVbPetx1NedMnopFvNcSPo6/tCpnxmd7666VV9Td9G+8hCVXyZkDvP4xFs3bjcSQ6bO2va71dmM99O0XVL8wKA==
   dependencies:
     archiver "^5.3.0"
     arweave "1.13.7"


### PR DESCRIPTION
This bump is needed so we can properly evaluate `safeGet` interactions on the `testnet-contract`

```
"height": 1293667,
"input": {
"function": "tick"
},
"owner": "QGWqtJdLLgm2ehFWiiPzMaoFLD50CnGuzZIPEdoDRGQ",
"valid": false,
"error": "TypeError: SmartWeave.safeArweaveGet is not a function\n    at tick (eval at create (/usr/src/app/node_modules/warp-contracts/lib/cjs/core/modules/impl/HandlerExecutorFactory.js:163:42), <anonymous>:2480:26)\n    at JsHandlerApi.handle [as contractFunction] (eval at create (/usr/src/app/node_modules/warp-contracts/lib/cjs/core/modules/impl/HandlerExecutorFactory.js:163:42), <anonymous>:2661:16)\n    at JsHandlerApi.runContractFunction (/usr/src/app/node_modules/warp-contracts/lib/cjs/core/modules/impl/handler/JsHandlerApi.js:103:76)\n    at async JsHandlerApi.handle (/usr/src/app/node_modules/warp-contracts/lib/cjs/core/modules/impl/handler/JsHandlerApi.js:34:16)\n    at async CacheableStateEvaluator.doReadState (/usr/src/app/node_modules/warp-contracts/lib/cjs/core/modules/impl/DefaultStateEvaluator.js:186:32)\n    at async CacheableStateEvaluator.eval (/usr/src/app/node_modules/warp-contracts/lib/cjs/core/modules/impl/CacheableStateEvaluator.js:62:16)\n    at async HandlerBasedContract.readState (/usr/src/app/node_modules/warp-contracts/lib/cjs/contract/HandlerBasedContract.js:122:28)",
"id": "PHJiuSm1GHdHOmmKN54fOlUypNt3gNssBrD1gExuhOA"
},
```