### PR TITLE
feat(sortKey): add sortKey to contract response

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -19,4 +19,8 @@
 module.exports = {
   extends: ['@commitlint/config-conventional'],
   ignores: [(message) => message.includes('[skip ci]')],
+  rules: {
+    'header-max-length': [0, 'always'],
+    'body-max-line-length': [0, 'always'],
+  },
 };

--- a/src/api/warp.ts
+++ b/src/api/warp.ts
@@ -144,9 +144,10 @@ async function readThroughToContractState(
       contractTxId,
       cacheKey: cacheKey.toString(),
     });
-    const { cachedValue } = await inFlightRequest;
+    const { cachedValue, sortKey } = await inFlightRequest;
     return {
       ...cachedValue,
+      sortKey,
       evaluationOptions,
     };
   }
@@ -182,14 +183,16 @@ async function readThroughToContractState(
     });
 
   // await the response
-  const { cachedValue } = await requestMap.get(cacheId);
+  const { cachedValue, sortKey } = await requestMap.get(cacheId);
   logger?.debug('Successfully evaluated contract state.', {
     contractTxId,
     cacheKey: cacheKey.toString(),
+    sortKey,
   });
 
   return {
     ...cachedValue,
+    sortKey,
     evaluationOptions,
   };
 }

--- a/src/routes/contract.ts
+++ b/src/routes/contract.ts
@@ -15,7 +15,7 @@ export async function contractHandler(ctx: KoaContext, next: Next) {
   logger.debug('Fetching contract state', {
     contractTxId,
   });
-  const { state, evaluationOptions } = await getContractState({
+  const { state, evaluationOptions, sortKey } = await getContractState({
     contractTxId,
     warp,
     logger,
@@ -23,6 +23,7 @@ export async function contractHandler(ctx: KoaContext, next: Next) {
   ctx.body = {
     contractTxId,
     state,
+    sortKey,
     evaluationOptions,
   };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -69,7 +69,8 @@ export type ContractReservedResponse = ContractBaseResponse & {
 // Warp types
 
 export type EvaluatedContractState = EvalStateResult<any> & {
-  evaluationOptions?: Partial<EvaluationOptions>;
+  evaluationOptions: Partial<EvaluationOptions>;
+  sortKey: string;
 };
 
 export type EvaluatedReadInteraction = {


### PR DESCRIPTION
This allows those evaluating contract state using warp to use this service to bootstrap state from our cache

Example:
```typescript
const contractTxId =  'bLAgYxAdX2Ry-nt6aH2ixgvJXbpsEYm28NgJgyqfs-U';

// get contract manifest
const { evaluationOptions = {} } = await getContractManifest({
  contractTxId,
});

// Read the ArNS Registry Contract
const contract = await warp
  .contract(contractTxId)
  .setEvaluationOptions(evaluationOptions)
  .syncState(`http://localhost:3000/v1/contract/${contractTxId}`);
```