### PR TITLE
chore(refactor): remove `return next()` from router handlers

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -18,7 +18,7 @@ import { EvaluationOptions } from 'warp-contracts';
 
 export const ARNS_CONTRACT_ID_REGEX = '([a-zA-Z0-9-_s+]{43})';
 export const ARNS_CONTRACT_FIELD_REGEX =
-  '(balances|fees|ticker|owner|name|controller|auctions|settings|reserved|gateways|version)';
+  '(balances|fees|ticker|owner|name|controller|auctions|settings|reserved|gateways|version|lastTickedState|demandFactoring)';
 export const ARNS_NAME_REGEX = '([a-zA-Z0-9-s+]{1,51})';
 export const EVALUATION_TIMEOUT_MS = 10_000; // 10 sec state timeout
 export const allowedContractTypes = ['ant'] as const;

--- a/src/router.ts
+++ b/src/router.ts
@@ -34,7 +34,6 @@ import {
 } from './routes';
 import { swaggerDocs } from './routes/swagger';
 import { KoaContext } from './types';
-import { Next } from 'koa';
 
 const router: Router = new Router();
 
@@ -76,22 +75,22 @@ router.get(
 // RESTful API to easy get auction prices
 router.get(
   `/v1/contract/:contractTxId${ARNS_CONTRACT_ID_REGEX}/auctions/:name${ARNS_NAME_REGEX}`,
-  (ctx: KoaContext, next: Next) => {
+  (ctx: KoaContext) => {
     // set params for auction read interaction and then use our generic handler
     ctx.params.functionName = 'auction';
     ctx.query = {
       ...ctx.query,
       name: ctx.params.name,
     };
-    return contractReadInteractionHandler(ctx, next);
+    return contractReadInteractionHandler(ctx);
   },
 );
 router.get(
   `/v1/contract/:contractTxId${ARNS_CONTRACT_ID_REGEX}/price`,
-  (ctx: KoaContext, next: Next) => {
+  (ctx: KoaContext) => {
     // set params for auction read interaction and then use our generic handler
     ctx.params.functionName = 'priceForInteraction';
-    return contractReadInteractionHandler(ctx, next);
+    return contractReadInteractionHandler(ctx);
   },
 );
 // generic handler that handles read APIs for any contract function

--- a/src/routes/contract.ts
+++ b/src/routes/contract.ts
@@ -14,7 +14,6 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-import { Next } from 'koa';
 
 import {
   ContractRecordResponse,
@@ -25,7 +24,7 @@ import { getContractReadInteraction, getContractState } from '../api/warp';
 import { getWalletInteractionsForContract } from '../api/graphql';
 import { NotFoundError } from '../errors';
 
-export async function contractHandler(ctx: KoaContext, next: Next) {
+export async function contractHandler(ctx: KoaContext) {
   const { logger, warp } = ctx.state;
   const { contractTxId } = ctx.params;
   logger.debug('Fetching contract state', {
@@ -42,11 +41,9 @@ export async function contractHandler(ctx: KoaContext, next: Next) {
     sortKey,
     evaluationOptions,
   };
-
-  return next();
 }
 
-export async function contractInteractionsHandler(ctx: KoaContext, next: Next) {
+export async function contractInteractionsHandler(ctx: KoaContext) {
   const { arweave, logger, warp } = ctx.state;
   const { contractTxId, address } = ctx.params;
 
@@ -85,11 +82,9 @@ export async function contractInteractionsHandler(ctx: KoaContext, next: Next) {
     ...(address ? { address } : {}), // only include address if it was provided
     evaluationOptions,
   };
-
-  return next();
 }
 
-export async function contractFieldHandler(ctx: KoaContext, next: Next) {
+export async function contractFieldHandler(ctx: KoaContext) {
   const { contractTxId, field } = ctx.params;
   const { logger, warp } = ctx.state;
   logger.debug('Fetching contract field', {
@@ -114,11 +109,9 @@ export async function contractFieldHandler(ctx: KoaContext, next: Next) {
     [field]: contractField,
     evaluationOptions,
   };
-
-  return next();
 }
 
-export async function contractBalanceHandler(ctx: KoaContext, next: Next) {
+export async function contractBalanceHandler(ctx: KoaContext) {
   const { contractTxId, address } = ctx.params;
   const { logger, warp } = ctx.state;
   logger.debug('Fetching contract balance for wallet', {
@@ -138,10 +131,9 @@ export async function contractBalanceHandler(ctx: KoaContext, next: Next) {
     balance: balance ?? 0,
     evaluationOptions,
   };
-  return next();
 }
 
-export async function contractRecordHandler(ctx: KoaContext, next: Next) {
+export async function contractRecordHandler(ctx: KoaContext) {
   const { contractTxId, name } = ctx.params;
   const { warp, logger: _logger } = ctx.state;
 
@@ -187,10 +179,9 @@ export async function contractRecordHandler(ctx: KoaContext, next: Next) {
   }
 
   ctx.body = response;
-  return next();
 }
 
-export async function contractRecordFilterHandler(ctx: KoaContext, next: Next) {
+export async function contractRecordFilterHandler(ctx: KoaContext) {
   const { contractTxId } = ctx.params;
   const { warp, logger: _logger } = ctx.state;
   // TODO: add other query filters (e.g. endTimestamp)
@@ -240,10 +231,9 @@ export async function contractRecordFilterHandler(ctx: KoaContext, next: Next) {
     // TODO: include filters in response
     evaluationOptions,
   };
-  return next();
 }
 
-export async function contractReservedHandler(ctx: KoaContext, next: Next) {
+export async function contractReservedHandler(ctx: KoaContext) {
   const { contractTxId, name } = ctx.params;
   const { warp, logger: _logger } = ctx.state;
 
@@ -268,13 +258,9 @@ export async function contractReservedHandler(ctx: KoaContext, next: Next) {
   };
 
   ctx.body = response;
-  return next();
 }
 
-export async function contractReadInteractionHandler(
-  ctx: KoaContext,
-  next: Next,
-) {
+export async function contractReadInteractionHandler(ctx: KoaContext) {
   const { contractTxId, functionName } = ctx.params;
   const { warp, logger: _logger } = ctx.state;
   const { query: input } = ctx.request;
@@ -310,5 +296,4 @@ export async function contractReadInteractionHandler(
     result,
     evaluationOptions,
   };
-  return next();
 }

--- a/src/routes/prometheus.ts
+++ b/src/routes/prometheus.ts
@@ -14,14 +14,13 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-import { Next } from 'koa';
+
 import { KoaContext } from '../types.js';
 import * as promClient from 'prom-client';
 
 const metricsRegistry = promClient.register;
 promClient.collectDefaultMetrics({ register: metricsRegistry });
 
-export async function prometheusHandler(ctx: KoaContext, next: Next) {
+export async function prometheusHandler(ctx: KoaContext) {
   ctx.body = await metricsRegistry.metrics();
-  return next();
 }

--- a/src/routes/swagger.ts
+++ b/src/routes/swagger.ts
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 import { readFileSync } from 'fs';
-import { Next } from 'koa';
+
 import { koaSwagger } from 'koa2-swagger-ui';
 import YAML from 'yaml';
 
@@ -30,9 +30,8 @@ function loadSwaggerYAML() {
     throw Error('OpenAPI spec could not be read!');
   }
 }
-export function swaggerDocsJSON(ctx: KoaContext, next: Next) {
+export function swaggerDocsJSON(ctx: KoaContext) {
   ctx.response.body = JSON.stringify(loadSwaggerYAML(), null, 2);
-  return next();
 }
 
 export const swaggerDocs = koaSwagger({

--- a/src/routes/wallet.ts
+++ b/src/routes/wallet.ts
@@ -14,7 +14,7 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-import { Next } from 'koa';
+
 import { KoaContext } from '../types';
 import {
   getContractsTransferredToOrControlledByWallet,
@@ -25,7 +25,7 @@ import { allowedContractTypes } from '../constants';
 import * as _ from 'lodash';
 import { BadRequestError } from '../errors';
 
-export async function walletContractHandler(ctx: KoaContext, next: Next) {
+export async function walletContractHandler(ctx: KoaContext) {
   const { address } = ctx.params;
   const { logger, arweave, warp } = ctx.state;
   const { type } = ctx.query;
@@ -93,6 +93,4 @@ export async function walletContractHandler(ctx: KoaContext, next: Next) {
     contractTxIds: _.compact(validContractsOfType),
     type,
   };
-
-  return next();
 }


### PR DESCRIPTION
In koa, the use of `next()` allows for async middleware. It is not necessary, and actually creates unexpected behavior to use `return next()` within route handlers as it passes control flow to the next route that matches the request path, rather then returning the response. Going forward, `next()` is likely only needed in middlware, unless we have some special path chaining we are trying to do.