### PR TITLE
fix(regex): remove field regex for contract fields

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -17,8 +17,6 @@
 import { EvaluationOptions } from 'warp-contracts';
 
 export const ARNS_CONTRACT_ID_REGEX = '([a-zA-Z0-9-_s+]{43})';
-export const ARNS_CONTRACT_FIELD_REGEX =
-  '(balances|fees|ticker|owner|name|controller|auctions|settings|reserved|gateways|version|lastTickedState|demandFactoring)';
 export const ARNS_NAME_REGEX = '([a-zA-Z0-9-s+]{1,51})';
 export const EVALUATION_TIMEOUT_MS = 10_000; // 10 sec state timeout
 export const allowedContractTypes = ['ant'] as const;

--- a/src/router.ts
+++ b/src/router.ts
@@ -15,11 +15,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 import Router from '@koa/router';
-import {
-  ARNS_CONTRACT_FIELD_REGEX,
-  ARNS_CONTRACT_ID_REGEX,
-  ARNS_NAME_REGEX,
-} from './constants';
+import { ARNS_CONTRACT_ID_REGEX, ARNS_NAME_REGEX } from './constants';
 import {
   contractBalanceHandler,
   contractFieldHandler,
@@ -104,7 +100,7 @@ router.get(
 );
 // fallback for any other contract fields that don't include additional logic (i.e. this just returns partial contract state)
 router.get(
-  `/v1/contract/:contractTxId${ARNS_CONTRACT_ID_REGEX}/:field${ARNS_CONTRACT_FIELD_REGEX}`,
+  `/v1/contract/:contractTxId${ARNS_CONTRACT_ID_REGEX}/:field`,
   contractFieldHandler,
 );
 router.get(


### PR DESCRIPTION
We were using a regex to prevent arbitaray requests creating potential issues in the service. Given the expanding set of fields, and the desire to support ant contracts that may have extended schemas, we can remove this regex in the service. If the field does not exist on the state, a 404 will be returned.