### PR TITLE
fix(warp): do not use in memory lmdb cache

### DIFF
--- a/src/middleware/warp.ts
+++ b/src/middleware/warp.ts
@@ -39,10 +39,16 @@ const warp = WarpFactory.forMainnet(
   true,
   arweave,
 ).useStateCache(
-  new LmdbCache(defaultCacheOptions, {
-    maxEntriesPerContract: 1000,
-    minEntriesPerContract: 0,
-  }),
+  new LmdbCache(
+    {
+      ...defaultCacheOptions,
+      inMemory: false,
+    },
+    {
+      maxEntriesPerContract: 1000,
+      minEntriesPerContract: 0,
+    },
+  ),
 );
 
 export function warpMiddleware(ctx: KoaContext, next: Next) {


### PR DESCRIPTION
This may be causing issues with lmdb. Ensuring lmdb does not use `noSync` which does not flush state to disk and is enabled by default with `defaultCacheOptions`.

Docs: https://github.com/kriszyp/lmdb-js#lmdb-flags

Ticket: [PE-5072](https://ardrive.atlassian.net/browse/PE-5072)

[PE-5072]: https://ardrive.atlassian.net/browse/PE-5072?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ