### PR TITLE
chore(cache): bump read through promise cache capacity

### DIFF
--- a/src/api/warp.ts
+++ b/src/api/warp.ts
@@ -127,7 +127,7 @@ const contractReadInteractionCache: ReadThroughPromiseCache<
   }
 > = new ReadThroughPromiseCache({
   cacheParams: {
-    cacheCapacity: 10_000,
+    cacheCapacity: 1_000,
     cacheTTL: 1000 * 30, // 30 seconds
   },
   readThroughFunction: readThroughToContractReadInteraction,

--- a/src/api/warp.ts
+++ b/src/api/warp.ts
@@ -75,7 +75,7 @@ const contractStateCache: ReadThroughPromiseCache<
   EvaluatedContractState
 > = new ReadThroughPromiseCache({
   cacheParams: {
-    cacheCapacity: 100,
+    cacheCapacity: 10_000,
     cacheTTL: 1000 * 30, // 30 seconds
   },
   readThroughFunction: readThroughToContractState,
@@ -127,7 +127,7 @@ const contractReadInteractionCache: ReadThroughPromiseCache<
   }
 > = new ReadThroughPromiseCache({
   cacheParams: {
-    cacheCapacity: 100,
+    cacheCapacity: 10_000,
     cacheTTL: 1000 * 30, // 30 seconds
   },
   readThroughFunction: readThroughToContractReadInteraction,


### PR DESCRIPTION
We are using very little memory (<10% on average) and this will avoid thrashing of the cache when various requets come in.

<img width="850" alt="image" src="https://github.com/ar-io/arns-service/assets/12800001/a234c1b8-ba2f-49f0-8629-2afcc7f082ea">

