### PR TITLE
fix(warp): set default evaluation timeout to one hour

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -20,4 +20,6 @@ export const ARNS_CONTRACT_ID_REGEX = '([a-zA-Z0-9-_s+]{43})';
 export const ARNS_NAME_REGEX = '([a-zA-Z0-9-s+]{1,51})';
 export const EVALUATION_TIMEOUT_MS = 10_000; // 10 sec state timeout
 export const allowedContractTypes = ['ant'] as const;
-export const DEFAULT_EVALUATION_OPTIONS: Partial<EvaluationOptions> = {};
+export const DEFAULT_EVALUATION_OPTIONS: Partial<EvaluationOptions> = {
+  maxInteractionEvaluationTimeSeconds: 3600, // one hour
+};


### PR DESCRIPTION
…o true

This may help avoid issues when evaluating contracts with expensive interactions that do not have a contract-manifest set