### PR TITLE
fix(warp): set `inMemory` to `false` for sqlite database

### DIFF
--- a/src/middleware/warp.ts
+++ b/src/middleware/warp.ts
@@ -42,6 +42,7 @@ const warp = WarpFactory.forMainnet(
   new SqliteContractCache(
     {
       ...defaultCacheOptions,
+      inMemory: false,
       dbLocation: `./cache/warp/sqlite/state`,
     },
     {


### PR DESCRIPTION
This should have been already set, it may be causing the memory issues we saw in the service.