### PR TITLE
fix(warp): use `arweave.net` for state evaluation

### DIFF
--- a/src/middleware/arweave.ts
+++ b/src/middleware/arweave.ts
@@ -21,7 +21,7 @@ import Arweave from 'arweave';
 export const arweave = new Arweave({
   protocol: process.env.GATEWAY_PROTOCOL ?? 'https',
   port: process.env.GATEWAY_PORT ?? 443,
-  host: process.env.GATEWAY_HOST ?? 'ar-io.dev',
+  host: process.env.GATEWAY_HOST ?? 'arweave.net',
 });
 
 export function arweaveMiddleware(ctx: KoaContext, next: Next) {


### PR DESCRIPTION
We are seeing issues when evaluating against ar-io.dev. We will switch to arweave.net while those get sorted.