### PR TITLE
feat(warp): add block timestamp to interactions endpoint

### DIFF
--- a/src/api/graphql.ts
+++ b/src/api/graphql.ts
@@ -149,6 +149,7 @@ export async function getWalletInteractionsForContract(
                         }
                         block {
                             height
+                            timestamp
                         }
                     }
                 }
@@ -177,6 +178,7 @@ export async function getWalletInteractionsForContract(
         : undefined;
       interactions.set(e.node.id, {
         height: e.node.block.height,
+        timestamp: e.node.block.timestamp,
         input: parsedInput,
         owner: e.node.owner.address,
       });

--- a/src/types.ts
+++ b/src/types.ts
@@ -54,6 +54,7 @@ export type ArNSInteraction = {
   input: PstInput | undefined;
   height: number;
   owner: string;
+  timestamp: number;
   errorMessage?: string;
 };
 

--- a/tests/integration/routes.test.ts
+++ b/tests/integration/routes.test.ts
@@ -78,11 +78,12 @@ describe('Integration tests', () => {
     );
     expect(writeInteraction?.originalTxId).to.not.be.undefined;
     transferToAddress = address;
+    const interactionBlock = await arweave.blocks.getCurrent();
     contractInteractions.push({
-      height: (await arweave.blocks.getCurrent()).height,
+      height: interactionBlock.height,
       input: transferInteraction,
       owner: walletAddress,
-      timestamp: (await arweave.blocks.getCurrent()).timestamp,
+      timestamp: Math.floor(interactionBlock.timestamp / 1000),
       valid: true,
       id: writeInteraction!.originalTxId,
     });

--- a/tests/integration/routes.test.ts
+++ b/tests/integration/routes.test.ts
@@ -82,6 +82,7 @@ describe('Integration tests', () => {
       height: (await arweave.blocks.getCurrent()).height,
       input: transferInteraction,
       owner: walletAddress,
+      timestamp: (await arweave.blocks.getCurrent()).timestamp,
       valid: true,
       id: writeInteraction!.originalTxId,
     });


### PR DESCRIPTION
We already fetch the height, so easy enough to add the timestamp