### PR TITLE
feat(gql): add `sortKey` and validate interactions from GQL

### DIFF
--- a/src/api/graphql.ts
+++ b/src/api/graphql.ts
@@ -190,9 +190,9 @@ export async function getWalletInteractionsForContract(
         ? JSON.parse(inputTag.value)
         : undefined;
       const sortKey = await interactionSorter.createSortKey(
-        e.block.id,
+        e.node.block.id,
         e.node.id,
-        e.block.height,
+        e.node.block.height,
       );
       interactions.set(e.node.id, {
         height: e.node.block.height,

--- a/src/api/graphql.ts
+++ b/src/api/graphql.ts
@@ -16,7 +16,7 @@
  */
 import Arweave from 'arweave';
 import { ArNSInteraction } from '../types.js';
-import { TagsParser } from 'warp-contracts';
+import { LexicographicalInteractionsSorter, TagsParser } from 'warp-contracts';
 import logger from '../logger';
 
 export const MAX_REQUEST_SIZE = 100;
@@ -109,6 +109,7 @@ export async function getWalletInteractionsForContract(
   >;
 }> {
   const parser = new TagsParser();
+  const interactionSorter = new LexicographicalInteractionsSorter(arweave);
   const { address, contractTxId } = params;
   let hasNextPage = false;
   let cursor: string | undefined;
@@ -149,6 +150,7 @@ export async function getWalletInteractionsForContract(
                             value
                         }
                         block {
+                            id
                             height
                             timestamp
                         }
@@ -187,9 +189,15 @@ export async function getWalletInteractionsForContract(
       const parsedInput = inputTag?.value
         ? JSON.parse(inputTag.value)
         : undefined;
+      const sortKey = await interactionSorter.createSortKey(
+        e.block.id,
+        e.node.id,
+        e.block.height,
+      );
       interactions.set(e.node.id, {
         height: e.node.block.height,
         timestamp: e.node.block.timestamp,
+        sortKey,
         input: parsedInput,
         owner: e.node.owner.address,
       });

--- a/src/types.ts
+++ b/src/types.ts
@@ -54,6 +54,7 @@ export type ArNSInteraction = {
   input: PstInput | undefined;
   height: number;
   owner: string;
+  sortKey: string;
   timestamp: number;
   errorMessage?: string;
 };

--- a/tests/integration/routes.test.ts
+++ b/tests/integration/routes.test.ts
@@ -88,7 +88,7 @@ describe('Integration tests', () => {
       owner: walletAddress,
       timestamp: Math.floor(interactionBlock.timestamp / 1000),
       sortKey: await interactionSorter.createSortKey(
-        interactionBlock.hash,
+        interactionBlock.indep_hash,
         writeInteraction!.originalTxId,
         interactionBlock.height,
       ),

--- a/tests/integration/routes.test.ts
+++ b/tests/integration/routes.test.ts
@@ -18,7 +18,10 @@ import { describe } from 'mocha';
 import { expect } from 'chai';
 import axiosPackage from 'axios';
 import { arweave, createLocalWallet, warp } from './setup.test';
-import { JWKInterface } from 'warp-contracts';
+import {
+  JWKInterface,
+  LexicographicalInteractionsSorter,
+} from 'warp-contracts';
 import * as path from 'path';
 import * as fs from 'fs';
 import { ArNSInteraction } from '../../src/types';
@@ -37,6 +40,7 @@ describe('Integration tests', () => {
   let transferToAddress: string;
   let walletJWK: JWKInterface;
   const contractInteractions: ArNSInteraction[] = [];
+  const interactionSorter = new LexicographicalInteractionsSorter(arweave);
 
   before(async function () {
     // set a large timeout to 10 secs
@@ -84,6 +88,11 @@ describe('Integration tests', () => {
       input: transferInteraction,
       owner: walletAddress,
       timestamp: Math.floor(interactionBlock.timestamp / 1000),
+      sortKey: await interactionSorter.createSortKey(
+        interactionBlock.hash,
+        writeInteraction?.originalTxId,
+        interactionBlock.height,
+      ),
       valid: true,
       id: writeInteraction!.originalTxId,
     });

--- a/tests/integration/routes.test.ts
+++ b/tests/integration/routes.test.ts
@@ -81,6 +81,7 @@ describe('Integration tests', () => {
       },
     );
     expect(writeInteraction?.originalTxId).to.not.be.undefined;
+    transferToAddress = address;
     const interactionBlock = await arweave.blocks.getCurrent();
     contractInteractions.push({
       height: interactionBlock.height,

--- a/tests/integration/routes.test.ts
+++ b/tests/integration/routes.test.ts
@@ -81,7 +81,6 @@ describe('Integration tests', () => {
       },
     );
     expect(writeInteraction?.originalTxId).to.not.be.undefined;
-    transferToAddress = address;
     const interactionBlock = await arweave.blocks.getCurrent();
     contractInteractions.push({
       height: interactionBlock.height,
@@ -90,7 +89,7 @@ describe('Integration tests', () => {
       timestamp: Math.floor(interactionBlock.timestamp / 1000),
       sortKey: await interactionSorter.createSortKey(
         interactionBlock.hash,
-        writeInteraction?.originalTxId,
+        writeInteraction!.originalTxId,
         interactionBlock.height,
       ),
       valid: true,


### PR DESCRIPTION
New interactions example:

```json
{
  "height": 1311127,
  "timestamp": 1701123593,
  "sortKey": "000001311127,0000000000000,dde3bb75a7b976d2e627e65ba77eaa51d3d4ea80ede4785d2984d38b558f3a9c",
  "input": {
    "function": "buyRecord",
    "name": "zekkava0",
    "contractTxId": "atomic",
    "type": "lease",
    "years": 1,
    "auction": false
},
  "owner": "2sbEg15TKqH-GH1yyxsnBAshlfSK0lRqtMNq4Jrp4OI",
  "valid": true,
  "id": "wsbJ-O075SObUe78Eqf0Q2563rWso6evjL4JjrjO3Y4"
},
```