### PR TITLE
PE-5202: add a readthroughpromisecache for contract interactions 

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -96,3 +96,10 @@ export type EvaluatedReadInteraction = {
   result: any;
   evaluationOptions?: Partial<EvaluationOptions>;
 };
+
+export type GenericContractInteraction = Omit<
+  ArNSInteraction,
+  'valid' | 'errorMessage' | 'id'
+>;
+
+export type TransactionID = string;


### PR DESCRIPTION
Mapping times after the retrievals seems to be somewhat non-performant based on log outputs. We should investigate further. Example logs:
```
debug: Fetching contract interactions {"contractTxId":"-8A6RexFkpfWwuyVO98wzSFZh0d6VJuI-buTJvlwOJQ","method":"GET","path":"/v1/contract/-8A6RexFkpfWwuyVO98wzSFZh0d6VJuI-buTJvlwOJQ/interactions","timestamp":"2023-12-10T18:03:11.187Z","trace":"387b2d"}
debug: Mapping interactions {"contractTxId":"-8A6RexFkpfWwuyVO98wzSFZh0d6VJuI-buTJvlwOJQ","method":"GET","path":"/v1/contract/-8A6RexFkpfWwuyVO98wzSFZh0d6VJuI-buTJvlwOJQ/interactions","timestamp":"2023-12-10T18:03:11.187Z","trace":"387b2d"}
debug: Setting cache-control to max-age=30. {"method":"GET","path":"/v1/contract/-8A6RexFkpfWwuyVO98wzSFZh0d6VJuI-buTJvlwOJQ/interactions","timestamp":"2023-12-10T18:03:18.029Z","trace":"387b2d"}
debug: Completed request. {"method":"GET","path":"/v1/contract/-8A6RexFkpfWwuyVO98wzSFZh0d6VJuI-buTJvlwOJQ/interactions","responseTime":"6844ms","timestamp":"2023-12-10T18:03:18.030Z","trace":"387b2d"}
```