### PR TITLE
fix(gql): fix cacheKey construction for gql interactions

### DIFF
--- a/src/api/graphql.ts
+++ b/src/api/graphql.ts
@@ -25,7 +25,6 @@ import {
   LexicographicalInteractionsSorter,
   TagsParser,
 } from 'warp-contracts';
-import logger from '../logger';
 import { ReadThroughPromiseCache } from '@ardrive/ardrive-promise-cache';
 import winston from 'winston';
 
@@ -120,7 +119,7 @@ class ContractInteractionsCacheKey {
 
   toString(): string {
     return `${this.contractTxId}-${
-      this.blockHeight ? `this.blockHeight` : 'null'
+      this.blockHeight ? this.blockHeight : 'null'
     }${this.address ? `-${this.address}` : ''}`;
   }
 
@@ -176,6 +175,7 @@ export async function readThroughToWalletInteractionsForContract(
     contractTxId,
     address,
     blockHeight: blockHeightFilter,
+    logger,
   } = cacheKey;
   logger?.debug('Reading through to wallet interactions for contract...', {
     contractTxId,
@@ -270,7 +270,7 @@ export async function readThroughToWalletInteractionsForContract(
       const contractTag = parser.getContractTag(i.node);
 
       if (!inputTag || !contractTag) {
-        logger.debug('Invalid tags for interaction via GQL, ignoring...', {
+        logger?.debug('Invalid tags for interaction via GQL, ignoring...', {
           contractTxId,
           interactionId: i.node.id,
           inputTag,


### PR DESCRIPTION
The same cache key is being set for varying blockheights, causing the read through cache to return incorrect interactions when a new request with a different blockHeight is created before the cache has expired.

CC @arielmelendez 

### Logs before:
```bash
Reading through to wallet interactions for contract... {"blockHeightFilter":1321450,"cacheKey":"bLAgYxAdX2Ry-nt6aH2ixgvJXbpsEYm28NgJgyqfs-U-this.blockHeight","contractTxId":"bLAgYxAdX2Ry-nt6aH2ixgvJXbpsEYm28NgJgyqfs-U","method":"GET","path":"/v1/contract/bLAgYxAdX2Ry-nt6aH2ixgvJXbpsEYm28NgJgyqfs-U/interactions","timestamp":"2023-12-13T08:48:13.463Z","trace":"ecd1e3"}
```

Specifically: `"cacheKey":"bLAgYxAdX2Ry-nt6aH2ixgvJXbpsEYm28NgJgyqfs-U-this.blockHeight"`

### Logs after:
```bash
Reading through to wallet interactions for contract... {"blockHeightFilter":1321450,"cacheKey":"bLAgYxAdX2Ry-nt6aH2ixgvJXbpsEYm28NgJgyqfs-U-1321450","contractTxId":"bLAgYxAdX2Ry-nt6aH2ixgvJXbpsEYm28NgJgyqfs-U","method":"GET","path":"/v1/contract/bLAgYxAdX2Ry-nt6aH2ixgvJXbpsEYm28NgJgyqfs-U/interactions","timestamp":"2023-12-13T08:57:46.165Z","trace":"b2ea0e"}
```
Updated: `"cacheKey":"bLAgYxAdX2Ry-nt6aH2ixgvJXbpsEYm28NgJgyqfs-U-1321450"`
