### PR TITLE
feat(warp): bump warp to use evaluation timeout abort controllers

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "koa2-swagger-ui": "^5.8.0",
     "lodash": "^4.17.21",
     "prom-client": "^14.2.0",
-    "warp-contracts": "^1.4.26",
+    "warp-contracts": "1.4.28",
     "warp-contracts-sqlite": "^1.0.2",
     "winston": "^3.8.2",
     "yaml": "^2.3.1"

--- a/src/api/warp.ts
+++ b/src/api/warp.ts
@@ -24,13 +24,17 @@ import {
 } from 'warp-contracts';
 import {
   DEFAULT_EVALUATION_OPTIONS,
-  EVALUATION_TIMEOUT_MS,
+  DEFAULT_STATE_EVALUATION_TIMEOUT_MS,
   allowedContractTypes,
 } from '../constants';
 import { ContractType, EvaluatedContractState } from '../types';
-import { EvaluationError, NotFoundError, UnknownError } from '../errors';
+import {
+  EvaluationError,
+  EvaluationTimeoutError,
+  NotFoundError,
+  UnknownError,
+} from '../errors';
 import * as _ from 'lodash';
-import { EvaluationTimeoutError } from '../errors';
 import { createHash } from 'crypto';
 import Arweave from 'arweave';
 import { Tag } from 'arweave/node/lib/transaction';
@@ -56,6 +60,7 @@ class ContractStateCacheKey {
     public readonly blockHeight: number | undefined,
     public readonly evaluationOptions: Partial<EvaluationOptions>,
     public readonly warp: Warp,
+    public readonly signal: AbortSignal,
     public readonly logger?: winston.Logger,
   ) {}
 
@@ -177,6 +182,7 @@ async function readThroughToContractState(
     blockHeight: providedBlockHeight,
     warp,
     logger,
+    signal,
   } = cacheKey;
   logger?.debug('Reading through to contract state...', {
     contractTxId,
@@ -211,8 +217,11 @@ async function readThroughToContractState(
     .setEvaluationOptions(evaluationOptions);
 
   // set cached value for multiple requests during initial promise
+  // TODO: change this to `readStateBatch` one it supports sortKeys/blockHeights
   const readStatePromise = contract.readState(
     providedSortKey ?? providedBlockHeight,
+    undefined,
+    signal,
   );
   stateRequestMap.set(cacheId, readStatePromise);
 
@@ -279,6 +288,8 @@ export function handleWarpErrors(error: unknown): Error {
       error.message.includes('Use contract.setEvaluationOptions'))
   ) {
     return new EvaluationError(error.message);
+  } else if (error instanceof Error && error.name === 'AbortError') {
+    return new EvaluationTimeoutError();
   } else if (error instanceof Error && error.message.includes('404')) {
     return new NotFoundError(error.message);
   } else if (
@@ -297,6 +308,8 @@ export function handleWarpErrors(error: unknown): Error {
       `Unknown error occurred evaluating contract. ${error}`,
     );
   }
+
+  // TODO: catch abort signal errors and return EvaluationTimeoutError
 }
 
 // TODO: we can put this in a interface/class and update the resolved type
@@ -306,12 +319,14 @@ export async function getContractState({
   logger,
   sortKey = undefined,
   blockHeight = undefined,
+  signal = AbortSignal.timeout(DEFAULT_STATE_EVALUATION_TIMEOUT_MS),
 }: {
   contractTxId: string;
   warp: Warp;
   logger: winston.Logger;
   sortKey?: string | undefined;
   blockHeight?: number | undefined;
+  signal?: AbortSignal;
 }): Promise<EvaluatedContractState> {
   try {
     // get the contract manifest eval options by default
@@ -327,6 +342,7 @@ export async function getContractState({
         blockHeight,
         evaluationOptions,
         warp,
+        signal,
         logger,
       ),
     );
@@ -508,36 +524,6 @@ export function tagsToObject(tags: Tag[]): {
   }, {});
 }
 
-export async function validateStateWithTimeout({
-  contractTxId,
-  warp,
-  type,
-  address,
-  logger,
-}: {
-  contractTxId: string;
-  warp: Warp;
-  type?: ContractType;
-  address?: string;
-  logger: winston.Logger;
-}): Promise<unknown> {
-  return Promise.race([
-    validateStateAndOwnership({
-      contractTxId,
-      warp,
-      type,
-      address,
-      logger,
-    }),
-    new Promise((_, reject) =>
-      setTimeout(
-        () => reject(new EvaluationTimeoutError()),
-        EVALUATION_TIMEOUT_MS,
-      ),
-    ),
-  ]);
-}
-
 // TODO: this could be come a generic and return the full state of contract once validated
 export async function validateStateAndOwnership({
   contractTxId,
@@ -545,6 +531,7 @@ export async function validateStateAndOwnership({
   type,
   address,
   logger,
+  signal,
   sortKey = undefined,
   blockHeight = undefined,
 }: {
@@ -553,6 +540,7 @@ export async function validateStateAndOwnership({
   type?: ContractType;
   address?: string;
   logger: winston.Logger;
+  signal: AbortSignal;
   sortKey?: string | undefined;
   blockHeight?: number | undefined;
 }): Promise<boolean> {
@@ -562,6 +550,7 @@ export async function validateStateAndOwnership({
     logger,
     sortKey,
     blockHeight,
+    signal,
   });
   // TODO: use json schema validation schema logic. For now, these are just raw checks.
   const validateType =

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -18,7 +18,11 @@ import { EvaluationOptions } from 'warp-contracts';
 
 export const ARNS_CONTRACT_ID_REGEX = '([a-zA-Z0-9-_s+]{43})';
 export const ARNS_NAME_REGEX = '([a-zA-Z0-9-s+]{1,51})';
-export const EVALUATION_TIMEOUT_MS = 10_000; // 10 sec state timeout
+export const SUB_CONTRACT_EVALUATION_TIMEOUT_MS = 10_000; // 10 sec state timeout - non configurable
+export const DEFAULT_STATE_EVALUATION_TIMEOUT_MS = process.env
+  .EVALUATION_TIMEOUT_MS
+  ? +process.env.EVALUATION_TIMEOUT_MS
+  : 1000 * 60 * 2; // 2 min state timeout (should be <= koa request timeout)
 export const allowedContractTypes = ['ant'] as const;
 export const DEFAULT_EVALUATION_OPTIONS: Partial<EvaluationOptions> = {
   maxInteractionEvaluationTimeSeconds: 3600, // one hour

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -15,7 +15,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-// TODO: we could put a prometheus metric here to help fine tune what our evaluation limit should be
 export class BaseError extends Error {
   super(message: string) {
     this.message = message;
@@ -24,7 +23,8 @@ export class BaseError extends Error {
 }
 export class EvaluationTimeoutError extends BaseError {
   constructor() {
-    super(`Evaluation timed out for contract.`);
+    super(`Evaluation timed out.`);
+    // TODO: we could put a prometheus metric here to help fine tune what our evaluation limit should be
   }
 }
 export class EvaluationError extends BaseError {}

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -14,7 +14,6 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
-import { EVALUATION_TIMEOUT_MS } from './constants';
 
 // TODO: we could put a prometheus metric here to help fine tune what our evaluation limit should be
 export class BaseError extends Error {
@@ -25,7 +24,7 @@ export class BaseError extends Error {
 }
 export class EvaluationTimeoutError extends BaseError {
   constructor() {
-    super(`State evaluation exceeded limit of ${EVALUATION_TIMEOUT_MS}ms.`);
+    super(`Evaluation timed out for contract.`);
   }
 }
 export class EvaluationError extends BaseError {}

--- a/src/middleware/errors.ts
+++ b/src/middleware/errors.ts
@@ -16,7 +16,12 @@
  */
 import { KoaContext } from '../types';
 import { Next } from 'koa';
-import { BadRequestError, EvaluationError, NotFoundError } from '../errors';
+import {
+  BadRequestError,
+  EvaluationError,
+  EvaluationTimeoutError,
+  NotFoundError,
+} from '../errors';
 
 // globally handle errors and return proper status based on their type
 export async function errorMiddleware(ctx: KoaContext, next: Next) {
@@ -32,6 +37,9 @@ export async function errorMiddleware(ctx: KoaContext, next: Next) {
       ctx.body = error.message;
     } else if (error instanceof NotFoundError) {
       ctx.status = 404;
+      ctx.body = error.message;
+    } else if (error instanceof EvaluationTimeoutError) {
+      ctx.status = 408;
       ctx.body = error.message;
     } else {
       // log full stack trace when 503s are returned to client to help with debugging

--- a/yarn.lock
+++ b/yarn.lock
@@ -6997,10 +6997,10 @@ warp-contracts-sqlite@^1.0.2:
     better-sqlite3 "^8.3.0"
     safe-stable-stringify "^2.4.3"
 
-warp-contracts@^1.4.26:
-  version "1.4.26"
-  resolved "https://registry.yarnpkg.com/warp-contracts/-/warp-contracts-1.4.26.tgz#d0535b9628f1913b8fa3c2678ed778830cb81810"
-  integrity sha512-m+e5TggjxUF1TtcuKlcAyuVvkTXUi1W0W788iFzfhr7x2hnnfbGkBTiGBxhLu6VVKfxxegMMukn5ztRDmaK34w==
+warp-contracts@1.4.28:
+  version "1.4.28"
+  resolved "https://registry.yarnpkg.com/warp-contracts/-/warp-contracts-1.4.28.tgz#ee8d5331acff3031d2813a8e2372e47daa580cf2"
+  integrity sha512-l6n2Ph2eWVWFHh+ivi6UvZt7RVYIZc07m1FrvkC9L6MZzMoOFeQDPNOinPy1Z7dNZRjlq3q0NI9zgGtgZZFtYA==
   dependencies:
     archiver "^5.3.0"
     arweave "1.13.7"


### PR DESCRIPTION
This update allows us to pass abort signals to warp evaluation and sets a default timeout of 2 mins for state evaluation. Includes updates to our read-through promises to support AbortSignals so we do not continue doing work once the response is returned to the client. 