### PR TITLE
feat(prefetch): prefetch contract states on startup

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -29,8 +29,12 @@ import logger from './logger';
 import { uncaughtExceptionError } from './metrics';
 import { queryMiddleware } from './middleware/query';
 import { DEFAULT_REQUEST_TIMEOUT_MS } from './constants';
+import * as system from './system';
 
 const app = new Koa();
+
+// load arns contract state
+system.hydrateArnsContractState();
 
 // attach middlewares
 app.use(loggerMiddleware);

--- a/src/app.ts
+++ b/src/app.ts
@@ -33,8 +33,8 @@ import * as system from './system';
 
 const app = new Koa();
 
-// load arns contract state
-system.hydrateArnsContractState();
+// load arns contract state on startup
+system.prefetchContracts();
 
 // attach middlewares
 app.use(loggerMiddleware);

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,23 @@
+/**
+ * Copyright (C) 2022-2023 Permanent Data Solutions, Inc. All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+export const arnsContractTxId =
+  process.env.ARNS_CONTRACT_TX_ID ||
+  'bLAgYxAdX2Ry-nt6aH2ixgvJXbpsEYm28NgJgyqfs-U';
+
+export const prefetchContractTxIds: string[] = process.env.PREFETCH_CONTRACT_IDS
+  ? [arnsContractTxId, ...process.env.PREFETCH_CONTRACT_IDS.split(',')]
+  : [arnsContractTxId];

--- a/src/middleware/warp.ts
+++ b/src/middleware/warp.ts
@@ -32,7 +32,7 @@ LoggerFactory.INST.logLevel(
 /**
  * TODO: consider using warp-contracts-postgres cache for distributed state caching across instances
  */
-const warp = WarpFactory.forMainnet(
+export const warp = WarpFactory.forMainnet(
   {
     ...defaultCacheOptions,
   },

--- a/src/routes/contract.ts
+++ b/src/routes/contract.ts
@@ -50,6 +50,7 @@ export async function contractHandler(ctx: KoaContext) {
     logger,
     sortKey: requestedSortKey,
     blockHeight: requestedBlockHeight,
+    signal: AbortSignal.timeout(DEFAULT_STATE_EVALUATION_TIMEOUT_MS),
   });
   ctx.body = {
     contractTxId,

--- a/src/system.ts
+++ b/src/system.ts
@@ -1,0 +1,45 @@
+/**
+ * Copyright (C) 2022-2023 Permanent Data Solutions, Inc. All Rights Reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { getContractState } from './api/warp';
+import { prefetchContractTxIds } from './config';
+import logger from './logger';
+import { warp } from './middleware';
+
+export const hydrateArnsContractState = () => {
+  // non-blocking call to load arns contract state
+  logger.info('Pre-fetching contracts...', {
+    contractTxIds: prefetchContractTxIds,
+  });
+  // don't wait - just fire and forget
+  Promise.all(
+    prefetchContractTxIds.map((contractTxId: string) =>
+      getContractState({ contractTxId, warp, logger })
+        .then(() => {
+          logger.info('Successfully prefetched contract state', {
+            contractTxId,
+          });
+        })
+        .catch((err: unknown) => {
+          logger.error('Failed to prefetch contract state', {
+            err,
+            contractTxId,
+          });
+        }),
+    ),
+  );
+};

--- a/src/system.ts
+++ b/src/system.ts
@@ -20,7 +20,7 @@ import { prefetchContractTxIds } from './config';
 import logger from './logger';
 import { warp } from './middleware';
 
-export const hydrateArnsContractState = () => {
+export const prefetchContracts = () => {
   // non-blocking call to load arns contract state
   logger.info('Pre-fetching contracts...', {
     contractTxIds: prefetchContractTxIds,


### PR DESCRIPTION
This should help alleviate pain after new deploys, and hydrate caches for contracts that have a lot of interactions as early as possible.

There's more we can do on the deploy side to check the status of these contracts before opening the tasks up for requests. 