### PR TITLE
feat(warp): bump warp version and use sqlite and lmdb for contract an…

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "lodash": "^4.17.21",
     "p-limit": "3.1.0",
     "prom-client": "^14.2.0",
-    "warp-contracts": "^1.4.37",
+    "warp-contracts": "^1.4.40",
     "warp-contracts-lmdb": "^1.1.10",
     "warp-contracts-sqlite": "^1.0.2",
     "winston": "^3.8.2",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "lodash": "^4.17.21",
     "p-limit": "3.1.0",
     "prom-client": "^14.2.0",
-    "warp-contracts": "^1.4.40",
+    "warp-contracts": "1.4.39",
     "warp-contracts-lmdb": "^1.1.10",
     "warp-contracts-sqlite": "^1.0.2",
     "winston": "^3.8.2",

--- a/src/middleware/warp.ts
+++ b/src/middleware/warp.ts
@@ -57,8 +57,17 @@ export const warp = WarpFactory.forMainnet(
         ...defaultCacheOptions,
         dbLocation: `./cache/warp/lmdb/kv/${contractTxId}`,
       }),
+  )
+  .useContractCache(
+    new SqliteContractCache({
+      ...defaultCacheOptions,
+      dbLocation: `./cache/warp/sqlite/contracts`,
+    }),
+    new LmdbCache({
+      ...defaultCacheOptions,
+      dbLocation: `./cache/warp/lmdb/source`,
+    }),
   );
-// TODO: useContractCache when they support custom gateways (ref: https://github.com/warp-contracts/warp/pull/501)
 
 export function warpMiddleware(ctx: KoaContext, next: Next) {
   ctx.state.warp = warp;

--- a/yarn.lock
+++ b/yarn.lock
@@ -8460,10 +8460,10 @@ warp-contracts-sqlite@^1.0.2:
     better-sqlite3 "^8.3.0"
     safe-stable-stringify "^2.4.3"
 
-warp-contracts@^1.4.40:
-  version "1.4.40"
-  resolved "https://registry.yarnpkg.com/warp-contracts/-/warp-contracts-1.4.40.tgz#f67ce9c0cc728d5967e093e30295aaaacb28b3bd"
-  integrity sha512-5WhzlmOca9uca+zzrI0dtkmtV25kaxj1C68MVj+Q2Wzfe7gnYOHNH9E18NqB/eTfmBIyJpLjuaRnq3ar0qbLQQ==
+warp-contracts@1.4.39:
+  version "1.4.39"
+  resolved "https://registry.yarnpkg.com/warp-contracts/-/warp-contracts-1.4.39.tgz#b56f4baa61b633c04d8abba65ee5dfca333ffea5"
+  integrity sha512-Dyk9wjhYceLRSq+U5Ba8h2mTbMPeB1hjdnDhYJP825E7gcc3jGc12GTLynSBqx5eJscOtpGG5Z5SQNxcTOP7/A==
   dependencies:
     archiver "^5.3.0"
     arweave "1.14.4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8460,10 +8460,10 @@ warp-contracts-sqlite@^1.0.2:
     better-sqlite3 "^8.3.0"
     safe-stable-stringify "^2.4.3"
 
-warp-contracts@^1.4.37:
-  version "1.4.37"
-  resolved "https://registry.yarnpkg.com/warp-contracts/-/warp-contracts-1.4.37.tgz#d22d34750bb50638188ca40d53015207688d1f58"
-  integrity sha512-jDQQF4FqRCy6OAnsb87d9LMzVp18eRTFyDQp9QirLD2C7IwBAH2DVrfpVcyPeZuxw4bNz3CSVemdMS+oFJIldQ==
+warp-contracts@^1.4.40:
+  version "1.4.40"
+  resolved "https://registry.yarnpkg.com/warp-contracts/-/warp-contracts-1.4.40.tgz#f67ce9c0cc728d5967e093e30295aaaacb28b3bd"
+  integrity sha512-5WhzlmOca9uca+zzrI0dtkmtV25kaxj1C68MVj+Q2Wzfe7gnYOHNH9E18NqB/eTfmBIyJpLjuaRnq3ar0qbLQQ==
   dependencies:
     archiver "^5.3.0"
     arweave "1.14.4"


### PR DESCRIPTION
…d source cache

This should improve contract load times moving contract state to sqlite. We back this up to S3 so it is more performant on bootup.