### PR TITLE
fix(eval): limit evaluation time to 32-bit integer not nodejs max

### DIFF
--- a/src/api/warp.ts
+++ b/src/api/warp.ts
@@ -26,6 +26,7 @@ import {
   DEFAULT_EVALUATION_OPTIONS,
   DEFAULT_PAGES_PER_BATCH,
   DEFAULT_STATE_EVALUATION_TIMEOUT_MS,
+  INT_MAX_32_BIT,
   allowedContractTypes,
 } from '../constants';
 import { ContractType, EvaluatedContractState } from '../types';
@@ -216,7 +217,7 @@ async function readThroughToContractState(
     // Temporary fix: protect against setting a maxInteractionEvaluationTimeSeconds that is too large, warp should do this on all evaluation options
     // Reference: https://github.com/warp-contracts/warp/issues/509
     maxInteractionEvaluationTimeSeconds: Math.min(
-      Number.MAX_SAFE_INTEGER,
+      INT_MAX_32_BIT,
       evaluationOptions.maxInteractionEvaluationTimeSeconds ||
         DEFAULT_EVALUATION_OPTIONS.maxInteractionEvaluationTimeSeconds,
     ),

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -24,6 +24,7 @@ export const BLOCKLISTED_CONTRACT_IDS = new Set(
     ? process.env.BLOCKLISTED_CONTRACT_IDS.split(',')
     : ['fbU8Y4NMKKzP4rmAYeYj6tDrVDo9XNbdyq5IZPA31WQ'],
 );
+export const INT_MAX_32_BIT = 2147483647;
 export const MAX_PATH_DEPTH = 5;
 export const ARWEAVE_TX_ID_REGEX = '([a-zA-Z0-9-_s+]{43})';
 export const ARNS_NAME_REGEX = '([a-zA-Z0-9-s+]{1,51})';


### PR DESCRIPTION
Error:
```
(node:1) TimeoutOverflowWarning: 9007199254740991000 does not fit into a 32-bit signed integer.
```